### PR TITLE
feat: 컨텐츠 알림 기능 추가

### DIFF
--- a/stitch-api/src/main/java/se/sowl/stitchapi/notification/controller/NotificationController.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/notification/controller/NotificationController.java
@@ -77,10 +77,18 @@ public class NotificationController {
 
     @PostMapping("/study-comment")
     public CommonResponse<NotificationResponse> createNewCommentNotification(
-            @RequestParam("studyPostId") Long studyPostId,
-            @RequestParam("commentWriterId") Long commentWriterId
+            @RequestParam("commentId") Long commentId
     ){
-        NotificationResponse response = notificationService.createNewCommentNotification(studyPostId, commentWriterId);
+        NotificationResponse response = notificationService.createNewCommentNotification(commentId);
+        return CommonResponse.ok(response);
+    }
+
+    @PostMapping("/study-content")
+    public CommonResponse<List<NotificationResponse>> createNewContentNotification(
+            @RequestParam("studyContentId") Long studyContentId,
+            @RequestParam("contentWriterId") Long contentWriterId
+    ){
+        List<NotificationResponse> response = notificationService.createNewContentNotification(studyContentId, contentWriterId);
         return CommonResponse.ok(response);
     }
 }

--- a/stitch-api/src/main/java/se/sowl/stitchapi/notification/service/NotificationService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/notification/service/NotificationService.java
@@ -3,22 +3,25 @@ package se.sowl.stitchapi.notification.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import se.sowl.stitchapi.exception.NotificationException;
-import se.sowl.stitchapi.exception.StudyMemberException;
-import se.sowl.stitchapi.exception.StudyPostException;
-import se.sowl.stitchapi.exception.UserCamInfoException;
+import se.sowl.stitchapi.exception.*;
 import se.sowl.stitchapi.notification.dto.NotificationListResponse;
 import se.sowl.stitchapi.notification.dto.NotificationResponse;
 import se.sowl.stitchdomain.notification.domain.Notification;
 import se.sowl.stitchdomain.notification.enumm.NotificationType;
 import se.sowl.stitchdomain.notification.repository.NotificationRepository;
+import se.sowl.stitchdomain.study.domain.StudyContent;
 import se.sowl.stitchdomain.study.domain.StudyMember;
 import se.sowl.stitchdomain.study.domain.StudyPost;
+import se.sowl.stitchdomain.study.domain.StudyPostComment;
+import se.sowl.stitchdomain.study.enumm.MemberStatus;
+import se.sowl.stitchdomain.study.repository.StudyContentRepository;
 import se.sowl.stitchdomain.study.repository.StudyMemberRepository;
+import se.sowl.stitchdomain.study.repository.StudyPostCommentRepository;
 import se.sowl.stitchdomain.study.repository.StudyPostRepository;
 import se.sowl.stitchdomain.user.domain.UserCamInfo;
 import se.sowl.stitchdomain.user.repository.UserCamInfoRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -29,6 +32,8 @@ public class NotificationService {
     private final UserCamInfoRepository userCamInfoRepository;
     private final StudyMemberRepository studyMemberRepository;
     private final StudyPostRepository studyPostRepository;
+    private final StudyContentRepository studyContentRepository;
+    private final StudyPostCommentRepository studyPostCommentRepository;
 
     // 사용자 알림 목록 조회
     @Transactional
@@ -97,7 +102,7 @@ public class NotificationService {
                         "님이 '" + studyMember.getStudyPost().getTitle() + "' 스터디에 가입 신청했습니다.")
                 .link("/api/study-members/list?studyPostId=" + studyMember.getStudyPost().getId())
                 .notificationType(NotificationType.STUDY_APPLY)
-                .targetId(studyMember.getId())
+                .targetId(studyMember.getId()) // 알림의 대상 ID: 스터디 멤버 ID
                 .isRead(false)
                 .build();
 
@@ -145,12 +150,12 @@ public class NotificationService {
 
     // 알림 생성(새 댓글)
     @Transactional
-    public NotificationResponse createNewCommentNotification(Long studyPostId, Long commentWriterId) {
-        StudyPost studyPost = studyPostRepository.findById(studyPostId)
-                .orElseThrow(StudyPostException.StudyPostNotFoundException::new);
+    public NotificationResponse createNewCommentNotification(Long commentId) {
+        StudyPostComment comment = studyPostCommentRepository.findById(commentId)
+                .orElseThrow(StudyPostException.StudyPostCommentNotFoundException::new);
 
-        UserCamInfo commentWriter = userCamInfoRepository.findById(commentWriterId)
-                .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+        StudyPost studyPost = comment.getStudyPost();
+        UserCamInfo commentWriter = comment.getUserCamInfo();
 
         // 게시글 작성자에게만 알림 (자신의 글에 자신이 댓글을 달면 알림 제외)
         if (!studyPost.getUserCamInfo().getId().equals(commentWriter.getId())) {
@@ -160,7 +165,7 @@ public class NotificationService {
                             "님이 '" + studyPost.getTitle() + "' 게시글에 댓글을 남겼습니다.")
                     .link("/api/study-posts/" + studyPost.getId() + "/comments")
                     .notificationType(NotificationType.STUDY_COMMENT_ADDED)
-                    .targetId(studyPost.getId())
+                    .targetId(comment.getId()) // 댓글 ID를 타겟으로 설정
                     .isRead(false)
                     .build();
 
@@ -169,5 +174,44 @@ public class NotificationService {
         }
 
         return null; // 자신의 글에 자신이 댓글을 달면 알림 없음
+    }
+
+    @Transactional
+    public List<NotificationResponse> createNewContentNotification(Long studyContentId, Long contentWriterId) {
+        StudyContent studyContent = studyContentRepository.findById(studyContentId)
+                .orElseThrow(StudyContentException.ContentNotFoundException::new);
+
+        StudyPost studyPost = studyContent.getStudyPost();
+
+        UserCamInfo contentWriter = userCamInfoRepository.findById(contentWriterId)
+                .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+
+        // 해당 스터디의 모든 멥버 조회 (승인된 멤버만)
+        List<StudyMember> studyMembers = studyMemberRepository.findByStudyPostAndMemberStatus(
+                studyPost, MemberStatus.APPROVED);
+
+        // 생성된 알림 응답을 저장할 리스트
+        List<NotificationResponse> notificationResponses = new ArrayList<>();
+
+        for (StudyMember member : studyMembers) {
+            // 자신이 작성한 컨텐츠에 대해서는 알림을 받지 않음
+            if (!member.getUserCamInfo().getId().equals(contentWriter.getId())) {
+                Notification notification = Notification.builder()
+                        .userCamInfo(member.getUserCamInfo()) // 알림 받는 당사자: 스터디 멤버
+                        .message(contentWriter.getUser().getName() +
+                                "님이 '" + studyPost.getTitle() + "' 스터디에 '" +
+                                studyContent.getTitle() + "' 컨텐츠를 추가했습니다.")
+                        .link("/api/study-contents/" + studyContent.getId())
+                        .notificationType(NotificationType.STUDY_CONTENT_ADDED)
+                        .targetId(studyContent.getId())
+                        .isRead(false)
+                        .build();
+
+                // 알림 저장 후 응답 리스트에 추가
+                Notification savedNotification = notificationRepository.save(notification);
+                notificationResponses.add(NotificationResponse.from(savedNotification));
+            }
+        }
+        return notificationResponses;
     }
 }

--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyContentService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyContentService.java
@@ -7,6 +7,7 @@ import se.sowl.stitchapi.exception.StudyContentException;
 import se.sowl.stitchapi.exception.StudyMemberException;
 import se.sowl.stitchapi.exception.StudyPostException;
 import se.sowl.stitchapi.exception.UserCamInfoException;
+import se.sowl.stitchapi.notification.service.NotificationService;
 import se.sowl.stitchapi.study.dto.request.StudyContentRequest;
 import se.sowl.stitchapi.study.dto.response.StudyContentDetailResponse;
 import se.sowl.stitchapi.study.dto.response.StudyContentListResponse;
@@ -32,6 +33,7 @@ public class StudyContentService {
     private final StudyPostRepository studyPostRepository;
     private final StudyMemberRepository studyMemberRepository;
     private final UserCamInfoRepository userCamInfoRepository;
+    private final NotificationService notificationService;
 
 
     /**
@@ -58,6 +60,8 @@ public class StudyContentService {
                 .studyContentType(request.getContentType())
                 .build();
         StudyContent savedStudyContent = studyContentRepository.save(studyContent);
+
+        notificationService.createNewContentNotification(savedStudyContent.getId(), userCamInfoId);
 
         return StudyContentResponse.from(savedStudyContent);
     }

--- a/stitch-domain/src/main/java/se/sowl/stitchdomain/notification/repository/NotificationRepository.java
+++ b/stitch-domain/src/main/java/se/sowl/stitchdomain/notification/repository/NotificationRepository.java
@@ -2,9 +2,11 @@ package se.sowl.stitchdomain.notification.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.sowl.stitchdomain.notification.domain.Notification;
+import se.sowl.stitchdomain.notification.enumm.NotificationType;
 import se.sowl.stitchdomain.user.domain.UserCamInfo;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -13,4 +15,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // 알림 읽음 처리
     List<Notification> findByUserCamInfoAndIsReadFalse(UserCamInfo userCamInfo);
+
+    Optional<Notification> findFirstByTargetIdAndNotificationTypeOrderByCreatedAtDesc(
+            Long targetId, NotificationType notificationType);
 }

--- a/stitch-domain/src/main/java/se/sowl/stitchdomain/study/repository/StudyMemberRepository.java
+++ b/stitch-domain/src/main/java/se/sowl/stitchdomain/study/repository/StudyMemberRepository.java
@@ -33,4 +33,9 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
      * 특정 스터디에서 특정 역할(리더 등)을 가진 멤버 조회
      */
     Optional<StudyMember> findByStudyPostAndMemberRole(StudyPost studyPost, MemberRole memberRole);
+
+    /**
+     * 특정 스터디에서 특정 사용자의 멤버십 정보 조회 (상태가 승인된 경우)
+     */
+    List<StudyMember> findByStudyPostAndMemberStatus(StudyPost studyPost, MemberStatus memberStatus);
 }


### PR DESCRIPTION
## 🛰️ Issue Number
# 13

## 🪐 작업 내용
- NotificationService에 컨텐츠 알림 생성 메서드(createNewContentNotification) 추가
- NotificationController에 컨텐츠 알림 엔드포인트(/study-content) 추가
- NotificationRepository에 필요한 쿼리 메서드 추가
- StudyMemberRepository에 스터디별 승인된 멤버 조회 메서드 추가
- StudyContentService에서 새로운 컨텐츠 생성 시 알림 연동 구현
- StudyContentServiceTest에 알림 연동 테스트 케이스 추가
- 
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
