### PR TITLE
feat: 사용자 정보 응답에 userCamInfoId 추가

### DIFF
--- a/stitch-api/src/main/java/se/sowl/stitchapi/user/dto/request/UserInfoRequest.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/user/dto/request/UserInfoRequest.java
@@ -18,4 +18,5 @@ public class UserInfoRequest {
     private String name;
     private String nickname;
     private String provider;
+    private Long userCamInfoId;
 }

--- a/stitch-api/src/main/java/se/sowl/stitchapi/user/service/UserService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/user/service/UserService.java
@@ -33,10 +33,12 @@ public class UserService {
         String majorName = null;
         Long campusId = null;
         String campusName = null;
+        Long useCamInfoId = null;
 
         if (user.isCampusCertified()) {
             UserCamInfo userCamInfo = userCamInfoRepository.findByUser(user)
                     .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+            useCamInfoId = userCamInfo.getId();
 
             if (userCamInfo.getMajor() != null) {
                 majorId = userCamInfo.getMajor().getId();
@@ -58,7 +60,8 @@ public class UserService {
                 campusName,
                 user.getName(),
                 user.getNickname(),
-                user.getProvider()
+                user.getProvider(),
+                useCamInfoId
         );
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
# fix/19
## 🪐 작업 내용
- UserInfoRequest DTO에 userCamInfoId 필드 추가
- getUserInfo 메서드에서 userCamInfoId를 응답에 포함하도록 수정
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
