### PR TITLE
feat: 스터디 멤버 조회 기능 추가

### DIFF
--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/controller/StudyMemberController.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/controller/StudyMemberController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import se.sowl.stitchapi.common.CommonResponse;
 import se.sowl.stitchapi.study.dto.request.ChangeLeaderRequest;
 import se.sowl.stitchapi.study.dto.request.StudyMemberApplyRequest;
+import se.sowl.stitchapi.study.dto.response.MyStudyResponse;
 import se.sowl.stitchapi.study.dto.response.StudyMemberResponse;
 import se.sowl.stitchapi.study.service.StudyMemberService;
 
@@ -45,8 +46,8 @@ public class StudyMemberController {
     }
 
     @GetMapping("/list")
-    public CommonResponse<List<StudyMemberResponse>> getStudyMember(){
-        List<StudyMemberResponse> responses = studyMemberService.getStudyMembers();
+    public CommonResponse<List<StudyMemberResponse>> getStudyMember(@RequestParam("studyPostId") Long studyPostId) {
+        List<StudyMemberResponse> responses = studyMemberService.getStudyMembers(studyPostId);
         return CommonResponse.ok(responses);
     }
 
@@ -68,4 +69,30 @@ public class StudyMemberController {
         StudyMemberResponse response = studyMemberService.changeLeader(request, userCamInfoId);
         return CommonResponse.ok(response);
     }
+
+    @GetMapping("/applicants")
+    public CommonResponse<List<StudyMemberResponse>> getStudyApplicants(
+            @RequestParam("studyPostId") Long studyPostId,
+            @RequestParam("userCamInfoId") Long userCamInfoId
+            ) {
+        List<StudyMemberResponse> responses = studyMemberService.getApplicantsMyStudy(studyPostId, userCamInfoId);
+        return CommonResponse.ok(responses);
+    }
+
+    @GetMapping("/my-applications")
+    public CommonResponse<List<MyStudyResponse>> getMyApplications(
+            @RequestParam("userCamInfoId") Long userCamInfoId
+    ) {
+        List<MyStudyResponse> responses = studyMemberService.getMyApplications(userCamInfoId);
+        return CommonResponse.ok(responses);
+    }
+
+    @GetMapping("/my-studies")
+    public CommonResponse<List<MyStudyResponse>> getMyStudies(
+            @RequestParam("userCamInfoId") Long userCamInfoId
+    ) {
+        List<MyStudyResponse> responses = studyMemberService.getMyJoinedStudies(userCamInfoId);
+        return CommonResponse.ok(responses);
+    }
+
 }

--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/dto/response/MyStudyResponse.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/dto/response/MyStudyResponse.java
@@ -1,0 +1,49 @@
+package se.sowl.stitchapi.study.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import se.sowl.stitchdomain.study.domain.StudyMember;
+import se.sowl.stitchdomain.study.enumm.MemberRole;
+import se.sowl.stitchdomain.study.enumm.MemberStatus;
+import se.sowl.stitchdomain.study.enumm.StudyStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MyStudyResponse {
+    // 스터디 정보
+    private Long studyPostId;
+    private String studyTitle;
+    private String studyContent;
+    private StudyStatus studyStatus;
+    private LocalDateTime studyCreatedAt;
+
+    // 내 참여 정보
+    private Long membershipId;
+    private MemberRole myRole;
+    private MemberStatus myStatus;
+    private LocalDateTime joinedAt;
+
+    // 스터디 작성자 정보
+    private String authorName;
+    private String authorNickname;
+
+    public static MyStudyResponse from(StudyMember studyMember) {
+        return MyStudyResponse.builder()
+                .studyPostId(studyMember.getStudyPost().getId())
+                .studyTitle(studyMember.getStudyPost().getTitle())
+                .studyContent(studyMember.getStudyPost().getContent())
+                .studyStatus(studyMember.getStudyPost().getStudyStatus())
+                .studyCreatedAt(studyMember.getStudyPost().getCreatedAt())
+                .membershipId(studyMember.getId())
+                .myRole(studyMember.getMemberRole())
+                .myStatus(studyMember.getMemberStatus())
+                .joinedAt(studyMember.getCreatedAt())
+                .authorName(studyMember.getStudyPost().getUserCamInfo().getUser().getName())
+                .authorNickname(studyMember.getStudyPost().getUserCamInfo().getUser().getNickname())
+                .build();
+    }
+}

--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyMemberService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyMemberService.java
@@ -9,6 +9,7 @@ import se.sowl.stitchapi.exception.UserCamInfoException;
 import se.sowl.stitchapi.notification.service.NotificationService;
 import se.sowl.stitchapi.study.dto.request.ChangeLeaderRequest;
 import se.sowl.stitchapi.study.dto.request.StudyMemberApplyRequest;
+import se.sowl.stitchapi.study.dto.response.MyStudyResponse;
 import se.sowl.stitchapi.study.dto.response.StudyMemberResponse;
 import se.sowl.stitchdomain.study.domain.StudyMember;
 import se.sowl.stitchdomain.study.domain.StudyPost;
@@ -45,6 +46,7 @@ public class StudyMemberService {
         
         // 이미 신청했거나 멤버인지 확인 
         boolean alreadyApplied = studyMemberRepository.existsByStudyPostAndUserCamInfo(studyPost, userCamInfo);
+
         if (alreadyApplied) {
             throw new StudyMemberException.AlreadyAppliedOrMemberException();
         }
@@ -124,9 +126,16 @@ public class StudyMemberService {
         return studyMember;
     }
 
-    @Transactional
-    public List<StudyMemberResponse> getStudyMembers(){
-        return studyMemberRepository.findAll().stream()
+    /*
+     * 스터디 멤버 목록 조회(승인된 멤버만)
+     */
+    @Transactional(readOnly = true)
+    public List<StudyMemberResponse> getStudyMembers(Long studyPostId) {
+        StudyPost studyPost = studyPostRepository.findById(studyPostId)
+                .orElseThrow(StudyPostException.StudyPostNotFoundException::new);
+
+        return studyMemberRepository.findByStudyPostAndMemberStatus(studyPost, MemberStatus.APPROVED)
+                .stream()
                 .map(StudyMemberResponse::from)
                 .toList();
     }
@@ -187,4 +196,58 @@ public class StudyMemberService {
         return StudyMemberResponse.from(newLeader);
     }
 
+    /*
+     * 내 스터디 신청자 목록 조회(리더만 가능)
+     */
+    @Transactional
+    public List<StudyMemberResponse> getApplicantsMyStudy(Long studyPostId, Long userCamInfoId){
+        StudyPost studyPost = studyPostRepository.findById(studyPostId)
+                .orElseThrow(StudyPostException.StudyPostNotFoundException::new);
+
+        UserCamInfo userCamInfo = userCamInfoRepository.findById(userCamInfoId)
+                .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+
+        // 리더인지 확인
+        boolean isLeader = studyMemberRepository.existsByStudyPostAndUserCamInfoAndMemberRole(
+                studyPost, userCamInfo, MemberRole.LEADER);
+
+        if (!isLeader) {
+            throw new StudyMemberException.NotLeaderException();
+        }
+
+        return studyMemberRepository.findByStudyPostAndMemberRole(studyPost, MemberRole.APPLICANT)
+                .stream()
+                .map(StudyMemberResponse::from)
+                .toList();
+    }
+
+    /*
+     * 내가 신청한 스터디 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<MyStudyResponse> getMyApplications(Long userCamInfoId) {
+        UserCamInfo userCamInfo = userCamInfoRepository.findById(userCamInfoId)
+                .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+
+        return studyMemberRepository.findByUserCamInfo(userCamInfo)
+                .stream()
+                .map(MyStudyResponse::from)
+                .toList();
+    }
+
+    /*
+     * 내가 속한 스터디 목록 조회(승인된 스터디만)
+     */
+    @Transactional(readOnly = true)
+    public List<MyStudyResponse> getMyJoinedStudies(Long userCamInfoId) {
+        UserCamInfo userCamInfo = userCamInfoRepository.findById(userCamInfoId)
+                .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+
+        List<StudyMember> joinedStudies = studyMemberRepository.findByUserCamInfoAndMemberStatus(
+                userCamInfo, MemberStatus.APPROVED);
+
+        return joinedStudies.stream()
+                .map(MyStudyResponse::from)
+                .toList();
+    }
 }

--- a/stitch-domain/src/main/java/se/sowl/stitchdomain/study/repository/StudyMemberRepository.java
+++ b/stitch-domain/src/main/java/se/sowl/stitchdomain/study/repository/StudyMemberRepository.java
@@ -38,4 +38,8 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
      * 특정 스터디에서 특정 사용자의 멤버십 정보 조회 (상태가 승인된 경우)
      */
     List<StudyMember> findByStudyPostAndMemberStatus(StudyPost studyPost, MemberStatus memberStatus);
+
+    List<StudyMember> findByUserCamInfo(UserCamInfo userCamInfo);
+
+    List<StudyMember> findByUserCamInfoAndMemberStatus(UserCamInfo userCamInfo, MemberStatus memberStatus);
 }


### PR DESCRIPTION
## 🛰️ Issue Number
feat/21
## 🪐 작업 내용
- 내가 신청한 스터디 목록 조회 API
- 내가 속한 스터디 목록 조회 API
- 내 스터디 신청자 목록 조회 API
- MyStudyResponse DTO 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
