### PR TITLE
feat: 댓글 수, 사용자가 작성한 댓글 목록 조회, api 추가

### DIFF
--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/controller/StudyPostCommentController.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/controller/StudyPostCommentController.java
@@ -18,7 +18,6 @@ public class StudyPostCommentController {
 
     private final StudyPostCommentService studyPostCommentService;
 
-    @Transactional
     @GetMapping("/list")
     @PreAuthorize("isAuthenticated()")
     public CommonResponse<List<StudyPostCommentResponse>> getCommentsByPostId(
@@ -53,5 +52,23 @@ public class StudyPostCommentController {
     ){
         studyPostCommentService.deleteStudyPostComment(commentId, userCamInfoId);
         return CommonResponse.ok(null);
+    }
+
+    @GetMapping("/count")
+    @PreAuthorize("isAuthenticated()")
+    public CommonResponse<Integer> getCommentCount(
+            @RequestParam("studyPostId") Long studyPostId
+    ){
+        int commentCount = studyPostCommentService.getCommentCount(studyPostId);
+        return CommonResponse.ok(commentCount);
+    }
+
+    @GetMapping("/myComments")
+    @PreAuthorize("isAuthenticated()")
+    public CommonResponse<List<StudyPostCommentResponse>> getMyComments(
+            @RequestParam("userCamInfoId") Long userCamInfoId
+    ){
+        List<StudyPostCommentResponse> response = studyPostCommentService.getMyComments(userCamInfoId);
+        return CommonResponse.ok(response);
     }
 }

--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyPostCommentService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyPostCommentService.java
@@ -79,4 +79,24 @@ public class StudyPostCommentService {
 
         studyPostCommentRepository.delete(comment);
     }
+
+    @Transactional
+    public int getCommentCount(Long studyPostId){
+        StudyPost studyPost = studyPostRepository.findById(studyPostId)
+                .orElseThrow(StudyPostException.StudyPostNotFoundException::new);
+
+        return studyPostCommentRepository.countByStudyPostId(studyPostId);
+    }
+
+    @Transactional
+    public List<StudyPostCommentResponse> getMyComments(Long userCamInfoId){
+        UserCamInfo userCamInfo = userCamInfoRepository.findById(userCamInfoId)
+                .orElseThrow(UserCamInfoException.UserCamNotFoundException::new);
+
+        List<StudyPostComment> comments = studyPostCommentRepository.findByUserCamInfoOrderByCreatedAtDesc(userCamInfo);
+
+        return comments.stream()
+                .map(StudyPostCommentResponse::from)
+                .toList();
+    }
 }

--- a/stitch-domain/src/main/java/se/sowl/stitchdomain/study/repository/StudyPostCommentRepository.java
+++ b/stitch-domain/src/main/java/se/sowl/stitchdomain/study/repository/StudyPostCommentRepository.java
@@ -2,9 +2,12 @@ package se.sowl.stitchdomain.study.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.sowl.stitchdomain.study.domain.StudyPostComment;
+import se.sowl.stitchdomain.user.domain.UserCamInfo;
 
 import java.util.List;
 
 public interface StudyPostCommentRepository extends JpaRepository<StudyPostComment, Long> {
     List<StudyPostComment> findByStudyPostId(Long studyPostId);
+    int countByStudyPostId(Long studyPostId);
+    List<StudyPostComment> findByUserCamInfoOrderByCreatedAtDesc(UserCamInfo userCamInfo);
 }


### PR DESCRIPTION
## 🛰️ Issue Number
feat/25
## 🪐 작업 내용
- StudyPostCommentController api 추가
- StudyPostCommentRepository 조회 메서드 추가
- StudyPostCommentService 댓글 수, 사용자자가 작성한 댓글 목록 조회 기능 추가
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
