### PR TITLE
fix: 스터디 신청 시 applyMessage 필드 누락 및 파라미터 불일치 수정

### DIFF
--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/controller/StudyMemberController.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/controller/StudyMemberController.java
@@ -53,10 +53,10 @@ public class StudyMemberController {
 
     @PostMapping("/leave")
     public CommonResponse<Void> leaveStudyMember(
-            @RequestParam("studyMemberId") Long studyMemberId,
+            @RequestParam("studyPostId") Long studyPostId,
             @RequestParam("userCamInfoId") Long userCamInfoId
     ){
-        studyMemberService.leaveStudyMember(studyMemberId, userCamInfoId);
+        studyMemberService.leaveStudyMember(studyPostId, userCamInfoId);
         return CommonResponse.ok(null);
     }
 

--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/dto/response/StudyMemberResponse.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/dto/response/StudyMemberResponse.java
@@ -21,6 +21,7 @@ public class StudyMemberResponse {
     private String userNickname;
     private MemberRole memberRole;
     private MemberStatus memberStatus;
+    private String applyMessage;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private String campusName;
@@ -36,6 +37,7 @@ public class StudyMemberResponse {
                 .userNickname(studyMember.getUserCamInfo().getUser().getNickname())
                 .memberRole(studyMember.getMemberRole())
                 .memberStatus(studyMember.getMemberStatus())
+                .applyMessage(studyMember.getApplyMessage())
                 .createdAt(studyMember.getCreatedAt())
                 .updatedAt(studyMember.getUpdatedAt())
                 .campusName(studyMember.getUserCamInfo().getCampus().getName())

--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyMemberService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyMemberService.java
@@ -56,6 +56,7 @@ public class StudyMemberService {
                 .userCamInfo(userCamInfo)
                 .memberRole(MemberRole.APPLICANT)
                 .memberStatus(MemberStatus.PENDING)
+                .applyMessage(request.getApplyMessage())
                 .build();
         
         StudyMember savedStudyMember = studyMemberRepository.save(studyMember);

--- a/stitch-domain/src/main/java/se/sowl/stitchdomain/study/domain/StudyMember.java
+++ b/stitch-domain/src/main/java/se/sowl/stitchdomain/study/domain/StudyMember.java
@@ -22,6 +22,9 @@ public class StudyMember {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "apply_message", length = 500)
+    private String applyMessage;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_post_id")
     private StudyPost studyPost;
@@ -47,11 +50,12 @@ public class StudyMember {
     private LocalDateTime updatedAt;
 
     @Builder
-    public StudyMember(StudyPost studyPost, UserCamInfo userCamInfo, MemberRole memberRole, MemberStatus memberStatus) {
+    public StudyMember(StudyPost studyPost, UserCamInfo userCamInfo, MemberRole memberRole, MemberStatus memberStatus, String applyMessage) {
         this.studyPost = studyPost;
         this.userCamInfo = userCamInfo;
         this.memberRole = memberRole;
         this.memberStatus = memberStatus;
+        this.applyMessage = applyMessage;
     }
     public void updateMemberRole(MemberRole memberRole) {
         this.memberRole = memberRole;


### PR DESCRIPTION
## 🛰️ Issue Number
fix/27
## 🪐 작업 내용
- StudyMember 엔터티에 applyMessage 필드 추가
- 스터디 신청 시 applyMessage 저장 로직 추가
- StudyMemberResponse에 applyMessage 필드 추가
- 스터디 탈퇴 API 파라미터 불일치 수정 (studyMemberId → studyPostId)
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
