### PR TITLE
fix: 리더 변경 시 스터디 소유권 이전 기능 추가

### DIFF
--- a/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyMemberService.java
+++ b/stitch-api/src/main/java/se/sowl/stitchapi/study/service/StudyMemberService.java
@@ -191,6 +191,8 @@ public class StudyMemberService {
             throw new StudyMemberException.NotApprovedMemberException();
         }
 
+        studyPost.changeOwner(newLeader.getUserCamInfo());
+
         currentLeader.updateMemberRole(MemberRole.MEMBER);
         newLeader.updateMemberRole(MemberRole.LEADER);
 

--- a/stitch-domain/src/main/java/se/sowl/stitchdomain/study/domain/StudyPost.java
+++ b/stitch-domain/src/main/java/se/sowl/stitchdomain/study/domain/StudyPost.java
@@ -66,6 +66,9 @@ public class StudyPost {
         this.title = title;
         this.content = content;
         this.studyStatus = studyStatus;
+    }
 
+    public void changeOwner(UserCamInfo newOwner) {
+        this.userCamInfo = newOwner;
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
fix/29
## 🪐 작업 내용
- StudyPost에 changeOwner() 메소드 추가
- 리더 변경 시 스터디 작성자도 새 리더로 변경
- 새 리더의 스터디 관리 권한 정상화
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
